### PR TITLE
Log client IP on HTTP parse errors via socket peer address

### DIFF
--- a/lib/puma/error_logger.rb
+++ b/lib/puma/error_logger.rb
@@ -80,11 +80,19 @@ module Puma
 
       query_string = env[QUERY_STRING]
 
+      # REMOTE_ADDR/X-Forwarded-For are only present once header parsing has
+      # completed, so they're absent for requests that fail to parse (e.g.
+      # HttpParserError). Fall back to the socket's peer address, which
+      # `req` (a Puma::Client) can still provide since it reads directly
+      # off the connection rather than the parsed env.
+      remote_addr = env[HTTP_X_FORWARDED_FOR] || env[REMOTE_ADDR]
+      remote_addr ||= req.peerip if req.respond_to?(:peerip)
+
       REQUEST_FORMAT % [
         env[REQUEST_METHOD],
         env[REQUEST_PATH] || env[PATH_INFO],
         query_string.nil? || query_string.empty? ? "" : "?#{query_string}",
-        env[HTTP_X_FORWARDED_FOR] || env[REMOTE_ADDR] || "-"
+        remote_addr || "-"
       ]
     end
 

--- a/test/test_error_logger.rb
+++ b/test/test_error_logger.rb
@@ -59,6 +59,65 @@ class TestErrorLogger < PumaTest
     assert_includes err,  'GET /debug?b=test" - (8.8.8.8))'
   end
 
+  ReqWithPeerip = Struct.new(:env, :body, :peerip)
+
+  def test_info_with_request_missing_remote_addr_falls_back_to_peerip
+    env = {
+      'REQUEST_METHOD' => 'GET',
+      'PATH_INFO' => '/'
+    }
+    req = ReqWithPeerip.new(env, nil, '203.0.113.5')
+
+    _, err = capture_io do
+      Puma::ErrorLogger.stdio.info(error: StandardError.new, req: req)
+    end
+
+    assert_includes err, '("GET /" - (203.0.113.5))'
+  end
+
+  def test_info_with_request_falls_back_to_ipv6_peerip
+    env = {
+      'REQUEST_METHOD' => 'GET',
+      'PATH_INFO' => '/'
+    }
+    req = ReqWithPeerip.new(env, nil, '2001:db8::1')
+
+    _, err = capture_io do
+      Puma::ErrorLogger.stdio.info(error: StandardError.new, req: req)
+    end
+
+    assert_includes err, '("GET /" - (2001:db8::1))'
+  end
+
+  def test_info_with_request_prefers_remote_addr_over_peerip
+    env = {
+      'REQUEST_METHOD' => 'GET',
+      'PATH_INFO' => '/',
+      'REMOTE_ADDR' => '198.51.100.7'
+    }
+    req = ReqWithPeerip.new(env, nil, '203.0.113.5')
+
+    _, err = capture_io do
+      Puma::ErrorLogger.stdio.info(error: StandardError.new, req: req)
+    end
+
+    assert_includes err, '("GET /" - (198.51.100.7))'
+  end
+
+  def test_info_with_request_no_remote_addr_no_peerip
+    env = {
+      'REQUEST_METHOD' => 'GET',
+      'PATH_INFO' => '/'
+    }
+    req = Req.new(env, nil)
+
+    _, err = capture_io do
+      Puma::ErrorLogger.stdio.info(error: StandardError.new, req: req)
+    end
+
+    assert_includes err, '("GET /" - (-))'
+  end
+
   def test_info_with_text
     _, err = capture_io do
       Puma::ErrorLogger.stdio.info(text: 'The client disconnected while we were reading data')

--- a/test/test_log_writer.rb
+++ b/test/test_log_writer.rb
@@ -141,7 +141,32 @@ class TestLogWriter < PumaTest
     sock.read
     sleep 0.1 # important so that the previous data is sent as a packet
     assert_match %r!HTTP parse error, malformed request!, log_writer.stderr.string
-    assert_match %r!\("GET #{path}" - \(-\)\)!, log_writer.stderr.string
+    assert_match %r!\("GET #{path}" - \(127\.0\.0\.1\)\)!, log_writer.stderr.string
+  ensure
+    sock.close if sock && !sock.closed?
+    server&.stop(true)
+  end
+
+  def test_parse_error_ipv6
+    skip "No IPv6 loopback available" unless Socket.ip_address_list.any?(&:ipv6_loopback?)
+
+    app = proc { |_env| [200, {"Content-Type" => "plain/text"}, ["hello\n"]] }
+    log_writer = Puma::LogWriter.strings
+    server = Puma::Server.new app, nil, {log_writer: log_writer}
+
+    host = '::1'
+    port = (server.add_tcp_listener host, 0).addr[1]
+    server.run
+
+    sock = TCPSocket.new host, port
+    path = "/"
+    params = "a"*1024*10
+
+    sock << "GET #{path}?a=#{params} HTTP/1.1\r\nHost: test.com\r\nConnection: close\r\n\r\n"
+    sock.read
+    sleep 0.1 # important so that the previous data is sent as a packet
+    assert_match %r!HTTP parse error, malformed request!, log_writer.stderr.string
+    assert_match %r!\("GET #{path}" - \(::1\)\)!, log_writer.stderr.string
   ensure
     sock.close if sock && !sock.closed?
     server&.stop(true)


### PR DESCRIPTION
REMOTE_ADDR/X-Forwarded-For are only populated in env once header parsing succeeds, so ErrorLogger#request_title logged "(-)" for the client IP on any request that failed to parse (e.g. HttpParserError, HttpParserError501) -- the exact cases where knowing the source IP matters most for blocking abusive clients.

The peer address is still available on the raw socket regardless of parse state, via Client#peerip. Fall back to it when REMOTE_ADDR and X-Forwarded-For are both absent.

peerip already normalizes IPv6 correctly on its own (unmap_ipv6 strips the IPv4-mapped prefix, native IPv6 passes through unchanged, per #3916/#3847), so no extra handling is needed here -- request_title just forwards whatever peerip returns. Added a unit test asserting a native IPv6 peerip renders unmodified, plus a real end-to-end test over an actual ::1 connection to prove it end to end.

test_log_writer's test_parse_error also gets a same-line fix: it asserted the client IP as "-", which was asserting the bug being fixed here. That test opens a real TCP connection from 127.0.0.1, so once request_title falls back to peerip, the log correctly shows (127.0.0.1) instead of (-).

### Description
Thank you for contributing! You're the best.

We can read your code, so consider leaving some comments here that are more about your motivations and decision making. Some things that may be helpful to address in your description:

- What original problem led to this PR?
- Are there related issues / prior discussions?
- What alternatives have been tried? Does this supersede previous attempts?
- Why do you make the choices you did? What are the tradeoffs?

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. You can delete or just add an X if you think its not applicable. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
